### PR TITLE
Resolve Issue 6 - continuous spatial bias

### DIFF
--- a/Functions to generate data and sample.R
+++ b/Functions to generate data and sample.R
@@ -38,7 +38,7 @@ strata1 <- genStrataLam(dat1$Lam, strata = strata, rows = rows, cols = cols)
 source("addSpatialBias.R")
 
 #spatial bias not correlated with environmental covariate
-biasfield <- addSpatialBias(strata1, probs = probs)
+biasfield <- addSpatialBias(strata1, maxprob = probs[1], correlated = FALSE)
 
 #spatial bias correlated with environmental covariate
 #biasfield <- addSpatialBias(strata1, probs = c(0.8, 0.5, 0.2))

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -12,8 +12,8 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   
   lookup <- data.frame(stratum = 1:nstrata, probs = NA)
   
-  #hard code for example
-  probs <- rep(c(0.5, 0.3, 0.1, 0.05, 0.01),5)
+  #hard code for example - change to linear trend but as strata
+  probs <- rep(c(0.5, 0.4, 0.3, 0.2, 0.1),5)
   
   if(is.null(probs)){
     lookup$probs <- runif(nrow(lookup), min = 0.1, max = 0.9)

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -21,20 +21,22 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
     lookup$probs <- probs
   }
   
-  covar_levels <- length(unique(probs))
-  covar_unique <- seq(0,1,length.out = covar_levels)
-  lookup_cov <- data.frame(probs = sort(unique(probs)), covar_unique = sort(covar_unique))
+  covar_levels <- length(unique(strata$x))
+  covar_unique <- seq(1,0,length.out = covar_levels)
+  #lookup_cov <- data.frame(probs = sort(unique(probs)), covar_unique = sort(covar_unique))
   
-  lookup$covariate <- lookup_cov$covar_unique[match(lookup$probs, lookup_cov$probs)]
+  #lookup$covariate <- lookup_cov$covar_unique[match(lookup$probs, lookup_cov$probs)]
   
   
   #add probabilites to strata output
   
   for(i in 1:nstrata){
     strata$stratprobs[strata$stratum == i] <- lookup$probs[i]
-    strata$covariate[strata$stratum == i] <- lookup$covariate[i]
+    #strata$covariate[strata$stratum == i] <- lookup$covariate[i]
   }
-  
+  for(j in 1:covar_levels){
+    strata$covariate[strata$x == j] <- covar_unique[j]
+  }
   
   
   # add detection probability per point defined by which grid square it is in

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -18,7 +18,7 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
     lookup <- data.frame(grid = 1:dim[1], probs = probseq)
     
     n     <- dim[1]                    # length of vector
-    rho   <- 0.948                   # desired correlation = cos(angle)
+    rho   <- 0.99                   # desired correlation = cos(angle)
     theta <- acos(rho)             # corresponding angle
     x1    <- probseq       # fixed given data
     x2    <- rnorm(n, 2, 0.5)      # new random data

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -22,7 +22,7 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   }
   
   covar_levels <- length(unique(strata$x))
-  covar_unique <- seq(1,0,length.out = covar_levels)
+  covar_unique <- seq(0.55,0.05,length.out = covar_levels)
   #lookup_cov <- data.frame(probs = sort(unique(probs)), covar_unique = sort(covar_unique))
   
   #lookup$covariate <- lookup_cov$covar_unique[match(lookup$probs, lookup_cov$probs)]
@@ -31,11 +31,11 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   #add probabilites to strata output
   
   for(i in 1:nstrata){
-    strata$stratprobs[strata$stratum == i] <- lookup$probs[i]
+    strata$covariate[strata$stratum == i] <- lookup$probs[i]
     #strata$covariate[strata$stratum == i] <- lookup$covariate[i]
   }
   for(j in 1:covar_levels){
-    strata$covariate[strata$x == j] <- covar_unique[j]
+    strata$stratprobs[strata$x == j] <- covar_unique[j]
   }
   
   

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -10,19 +10,19 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   
   
   dim = c(max(strata$x), max(strata$y))
-  minprob = maxprob/50 # keep the relative difference between maximum and minimum probabilities the same across different scenarios of maxprob (i.e. strength of bias is the same)
+  minprob = maxprob/10 # keep the relative difference between maximum and minimum probabilities the same across different scenarios of maxprob (i.e. strength of bias is the same)
   
   
   
   if (correlated == FALSE){
-    probseq <- seq(maxprob, minprob, length.out = dim[1])
+    probseq <-  exp(seq(log(maxprob), log(minprob), length.out = dim[1]))
     lookup <- data.frame(grid = 1:dim[1], probs = probseq)
     
     n     <- dim[1]                    # length of vector
-    rho   <- 0.98                   # desired correlation = cos(angle)
+    rho   <- 0.99                   # desired correlation = cos(angle)
     theta <- acos(rho)             # corresponding angle
     x1    <- probseq       # fixed given data
-    x2    <- rnorm(n, 0.5, 0.5)      # new random data
+    x2    <- rnorm(n, 2, 0.5)      # new random data
     X     <- cbind(x1, x2)         # matrix
     Xctr  <- scale(X, center=TRUE, scale=FALSE)   # centered columns (mean 0)
     
@@ -36,7 +36,7 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
     x <- Y[ , 2] + (1 / tan(theta)) * Y[ , 1]     # final new vector
     cor(x1, x)                                    # check correlation = rho
     
-    lookup$covariate <- x #+ max(x) #make positive only
+    lookup$covariate <- x+max(x) # ensure positive
     
     for(i in 1:dim[1]){
       strata$stratprobs[strata$x == i] <- lookup$probs[i]
@@ -46,9 +46,36 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   }
   
   if (correlated == TRUE){
-    print("help, no code here")
+    probseq <-  exp(seq(log(maxprob), log(minprob), length.out = dim[2]))
+    lookup <- data.frame(grid = dim[2]:1, probs = probseq)#positively correlated
+    
+    #define new variable for covariate to explain bias - correlated with true sampling probability
+    
+    n     <- dim[2]                    # length of vector
+    rho   <- 0.9                   # desired correlation = cos(angle)
+    theta <- acos(rho)             # corresponding angle
+    x1    <- probseq       # fixed given data
+    x2    <- rnorm(n, 2, 0.5)      # new random data
+    X     <- cbind(x1, x2)         # matrix
+    Xctr  <- scale(X, center=TRUE, scale=FALSE)   # centered columns (mean 0)
+    
+    Id   <- diag(n)                               # identity matrix
+    Q    <- qr.Q(qr(Xctr[ , 1, drop=FALSE]))      # QR-decomposition, just matrix Q
+    P    <- tcrossprod(Q)          # = Q Q'       # projection onto space defined by x1
+    x2o  <- (Id-P) %*% Xctr[ , 2]                 # x2ctr made orthogonal to x1ctr
+    Xc2  <- cbind(Xctr[ , 1], x2o)                # bind to matrix
+    Y    <- Xc2 %*% diag(1/sqrt(colSums(Xc2^2)))  # scale columns to length 1
+    
+    x <- Y[ , 2] + (1 / tan(theta)) * Y[ , 1]     # final new vector
+    cor(x1, x)                                    # check correlation = rho
+    
+    lookup$covariate <- x + max(x) #ensure positive
+    
+    for(i in 1:dim[2]){
+      strata$stratprobs[strata$y == i] <- lookup$probs[i]
+      strata$covariate[strata$y == i] <- lookup$covariate[i]
+    }
   }
-  
   
   # add detection probability per point defined by which grid square it is in
   return(strata)

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -14,7 +14,8 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   
   
   if (correlated == FALSE){
-    probseq <-  exp(seq(log(maxprob), log(minprob), length.out = dim[1]))
+    #probseq <-  exp(seq(log(maxprob), log(minprob), length.out = dim[1]))
+    probseq <-  seq(maxprob, minprob, length.out = dim[1])#linear
     lookup <- data.frame(grid = 1:dim[1], probs = probseq)
     
     n     <- dim[1]                    # length of vector
@@ -45,7 +46,8 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   }
   
   if (correlated == TRUE){
-    probseq <-  exp(seq(log(maxprob), log(minprob), length.out = dim[2]))
+    #probseq <-  exp(seq(log(maxprob), log(minprob), length.out = dim[1]))
+    probseq <-  seq(maxprob, minprob, length.out = dim[1])#linear
     lookup <- data.frame(grid = dim[2]:1, probs = probseq)#positively correlated
     
     #define new variable for covariate to explain bias - correlated with true sampling probability

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -8,40 +8,52 @@
 
 addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   
-  nstrata = length(unique(strata$stratum))
   
-  lookup <- data.frame(stratum = 1:nstrata, probs = NA)
+  dim = c(max(strata$x), max(strata$y))
+  minprob = maxprob/50 # keep the relative difference between maximum and minimum probabilities the same across different scenarios of maxprob (i.e. strength of bias is the same)
   
-  #hard code for example - change to linear trend but as strata
-  probs <- rep(c(0.5, 0.4, 0.3, 0.2, 0.1),5)
   
-  if(is.null(probs)){
-    lookup$probs <- runif(nrow(lookup), min = 0.1, max = 0.9)
-  } else {
-    lookup$probs <- probs
+  
+  if (correlated == FALSE){
+    probseq <- seq(maxprob, minprob, length.out = dim[1])
+    lookup <- data.frame(grid = 1:dim[1], probs = probseq)
+    
+    n     <- dim[1]                    # length of vector
+    rho   <- 0.98                   # desired correlation = cos(angle)
+    theta <- acos(rho)             # corresponding angle
+    x1    <- probseq       # fixed given data
+    x2    <- rnorm(n, 0.5, 0.5)      # new random data
+    X     <- cbind(x1, x2)         # matrix
+    Xctr  <- scale(X, center=TRUE, scale=FALSE)   # centered columns (mean 0)
+    
+    Id   <- diag(n)                               # identity matrix
+    Q    <- qr.Q(qr(Xctr[ , 1, drop=FALSE]))      # QR-decomposition, just matrix Q
+    P    <- tcrossprod(Q)          # = Q Q'       # projection onto space defined by x1
+    x2o  <- (Id-P) %*% Xctr[ , 2]                 # x2ctr made orthogonal to x1ctr
+    Xc2  <- cbind(Xctr[ , 1], x2o)                # bind to matrix
+    Y    <- Xc2 %*% diag(1/sqrt(colSums(Xc2^2)))  # scale columns to length 1
+    
+    x <- Y[ , 2] + (1 / tan(theta)) * Y[ , 1]     # final new vector
+    cor(x1, x)                                    # check correlation = rho
+    
+    lookup$covariate <- x #+ max(x) #make positive only
+    
+    for(i in 1:dim[1]){
+      strata$stratprobs[strata$x == i] <- lookup$probs[i]
+      strata$covariate[strata$x == i] <- lookup$covariate[i]
+    }
+    
   }
   
-  covar_levels <- length(unique(strata$x))
-  covar_unique <- seq(0.55,0.05,length.out = covar_levels)
-  #lookup_cov <- data.frame(probs = sort(unique(probs)), covar_unique = sort(covar_unique))
-  
-  #lookup$covariate <- lookup_cov$covar_unique[match(lookup$probs, lookup_cov$probs)]
-  
-  
-  #add probabilites to strata output
-  
-  for(i in 1:nstrata){
-    strata$covariate[strata$stratum == i] <- lookup$probs[i]
-    #strata$covariate[strata$stratum == i] <- lookup$covariate[i]
-  }
-  for(j in 1:covar_levels){
-    strata$stratprobs[strata$x == j] <- covar_unique[j]
+  if (correlated == TRUE){
+    print("help, no code here")
   }
   
   
   # add detection probability per point defined by which grid square it is in
   return(strata)
-
+  
+  
 }
 
 

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -8,76 +8,34 @@
 
 addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
   
-  dim = c(max(strata$x), max(strata$y))
-  minprob = maxprob/50 # keep the relative difference between maximum and minimum probabilities the same across different scenarios of maxprob (i.e. strength of bias is the same)
+  nstrata = length(unique(strata$stratum))
   
+  lookup <- data.frame(stratum = 1:nstrata, probs = NA)
   
+  #hard code for example
+  probs <- rep(c(0.5, 0.3, 0.1, 0.05, 0.01),5)
   
-  if (correlated == FALSE){
-    #probseq <-  exp(seq(log(maxprob), log(minprob), length.out = dim[1]))
-    probseq <-  seq(maxprob, minprob, length.out = dim[1])#linear
-    lookup <- data.frame(grid = 1:dim[1], probs = probseq)
-    
-    n     <- dim[1]                    # length of vector
-    rho   <- 0.99                   # desired correlation = cos(angle)
-    theta <- acos(rho)             # corresponding angle
-    x1    <- probseq       # fixed given data
-    x2    <- rnorm(n, 2, 0.5)      # new random data
-    X     <- cbind(x1, x2)         # matrix
-    Xctr  <- scale(X, center=TRUE, scale=FALSE)   # centered columns (mean 0)
-    
-    Id   <- diag(n)                               # identity matrix
-    Q    <- qr.Q(qr(Xctr[ , 1, drop=FALSE]))      # QR-decomposition, just matrix Q
-    P    <- tcrossprod(Q)          # = Q Q'       # projection onto space defined by x1
-    x2o  <- (Id-P) %*% Xctr[ , 2]                 # x2ctr made orthogonal to x1ctr
-    Xc2  <- cbind(Xctr[ , 1], x2o)                # bind to matrix
-    Y    <- Xc2 %*% diag(1/sqrt(colSums(Xc2^2)))  # scale columns to length 1
-    
-    x <- Y[ , 2] + (1 / tan(theta)) * Y[ , 1]     # final new vector
-    cor(x1, x)                                    # check correlation = rho
-    
-    lookup$covariate <- x
-    
-    for(i in 1:dim[1]){
-      strata$stratprobs[strata$x == i] <- lookup$probs[i]
-      strata$covariate[strata$x == i] <- lookup$covariate[i]
-    }
-    
+  if(is.null(probs)){
+    lookup$probs <- runif(nrow(lookup), min = 0.1, max = 0.9)
+  } else {
+    lookup$probs <- probs
   }
   
-  if (correlated == TRUE){
-    #probseq <-  exp(seq(log(maxprob), log(minprob), length.out = dim[1]))
-    probseq <-  seq(maxprob, minprob, length.out = dim[1])#linear
-    lookup <- data.frame(grid = dim[2]:1, probs = probseq)#positively correlated
-    
-    #define new variable for covariate to explain bias - correlated with true sampling probability
-    
-    n     <- dim[2]                    # length of vector
-    rho   <- 0.9                   # desired correlation = cos(angle)
-    theta <- acos(rho)             # corresponding angle
-    x1    <- probseq       # fixed given data
-    x2    <- rnorm(n, 2, 0.5)      # new random data
-    X     <- cbind(x1, x2)         # matrix
-    Xctr  <- scale(X, center=TRUE, scale=FALSE)   # centered columns (mean 0)
-    
-    Id   <- diag(n)                               # identity matrix
-    Q    <- qr.Q(qr(Xctr[ , 1, drop=FALSE]))      # QR-decomposition, just matrix Q
-    P    <- tcrossprod(Q)          # = Q Q'       # projection onto space defined by x1
-    x2o  <- (Id-P) %*% Xctr[ , 2]                 # x2ctr made orthogonal to x1ctr
-    Xc2  <- cbind(Xctr[ , 1], x2o)                # bind to matrix
-    Y    <- Xc2 %*% diag(1/sqrt(colSums(Xc2^2)))  # scale columns to length 1
-    
-    x <- Y[ , 2] + (1 / tan(theta)) * Y[ , 1]     # final new vector
-    cor(x1, x)                                    # check correlation = rho
-    
-    lookup$covariate <- x
-    
-    for(i in 1:dim[2]){
-      strata$stratprobs[strata$y == i] <- lookup$probs[i]
-      strata$covariate[strata$y == i] <- lookup$covariate[i]
-    }
+  covar_levels <- length(unique(probs))
+  covar_unique <- seq(0,1,length.out = covar_levels)
+  lookup_cov <- data.frame(probs = sort(unique(probs)), covar_unique = sort(covar_unique))
+  
+  lookup$covariate <- lookup_cov$covar_unique[match(lookup$probs, lookup_cov$probs)]
+  
+  
+  #add probabilites to strata output
+  
+  for(i in 1:nstrata){
+    strata$stratprobs[strata$stratum == i] <- lookup$probs[i]
+    strata$covariate[strata$stratum == i] <- lookup$covariate[i]
   }
-
+  
+  
   
   # add detection probability per point defined by which grid square it is in
   return(strata)

--- a/addSpatialBias.R
+++ b/addSpatialBias.R
@@ -18,7 +18,7 @@ addSpatialBias <- function(strata = strata, maxprob = NULL, correlated = FALSE){
     lookup <- data.frame(grid = 1:dim[1], probs = probseq)
     
     n     <- dim[1]                    # length of vector
-    rho   <- 0.9                   # desired correlation = cos(angle)
+    rho   <- 0.948                   # desired correlation = cos(angle)
     theta <- acos(rho)             # corresponding angle
     x1    <- probseq       # fixed given data
     x2    <- rnorm(n, 2, 0.5)      # new random data

--- a/runall.R
+++ b/runall.R
@@ -6,7 +6,8 @@ source("setParams.R")
 
 library(viridis)
 
-lambda <- -3
+lambda <- -3 #manageable number
+#env.beta <- 3 #stronger env effect
 
 #' The default parameters are as follows:
 #' 
@@ -124,15 +125,15 @@ legend(-10,360,c("Absence", "Presence"), pch = 21, col = "black", pt.bg = c(0,1)
 #' ### Structured model 
 #' 
 # #+ warning = FALSE, message = FALSE, error = FALSE, figure.align = "center"
-# source("Run models structured.R")
-# mod_1 <- structured_model(structured_data, dat1, biasfield, plotting = TRUE)
-# source("validation_function.R")
-# validation_1 <- validation_function(result=mod_1[[2]], resolution=c(10,10), join.stack=mod_1[[1]], model_type="structured", 
-#                                     structured_data = structured_data, dat1 = dat1, summary_results=T, qsize = 1, absolute=TRUE, dim = dim, plotting = TRUE)
-# validation_1_r <- validation_function(result=mod_1[[2]], resolution=c(10,10), join.stack=mod_1[[1]], model_type="structured", 
-#                                       structured_data = structured_data, dat1 = dat1, summary_results=T, qsize = 1, absolute=FALSE, dim = dim, plotting = TRUE)
+source("Run models structured.R")
+mod_1 <- structured_model(structured_data, dat1, biasfield, plotting = TRUE)
+source("validation_function.R")
+validation_1 <- validation_function(result=mod_1[[2]], resolution=c(10,10), join.stack=mod_1[[1]], model_type="structured",
+                                    structured_data = structured_data, dat1 = dat1, summary_results=T, qsize = 1, absolute=TRUE, dim = dim, plotting = TRUE)
+validation_1_r <- validation_function(result=mod_1[[2]], resolution=c(10,10), join.stack=mod_1[[1]], model_type="structured",
+                                      structured_data = structured_data, dat1 = dat1, summary_results=T, qsize = 1, absolute=FALSE, dim = dim, plotting = TRUE)
 
-#' ### Unstructured model 
+#' ### Unstructured model
 #' 
 #+ warning = FALSE, message = FALSE, error = FALSE
 source("Run models.R")
@@ -145,20 +146,20 @@ validation_2_r <- validation_function(result=mod_2[[2]], resolution=c(10,10), jo
 
 
 
-#' 
-#' #' ### Joint model 
-#' #' 
-#' #+ warning = FALSE, message = FALSE, error = FALSE
-#' #joint model (no covariate on bias)
-#' source("Run models joint.R")
-#' mod_3 <- joint_model(structured_data, unstructured_data, dat1, biasfield)
-#' source("validation_function.R")
-#' validation_3 <- validation_function(result=mod_3[[2]], resolution=c(10,10), join.stack=mod_3[[1]], model_type="joint", 
-#'                                     unstructured_data = unstructured_data, structured_data = structured_data,
-#'                                     dat1 = dat1, summary_results=T, absolute=TRUE, dim = dim, plotting = TRUE)
-#' validation_3_r <- validation_function(result=mod_3[[2]], resolution=c(10,10), join.stack=mod_3[[1]], model_type="joint", 
-#'                                       unstructured_data = unstructured_data, structured_data = structured_data,
-#'                                       dat1 = dat1, summary_results=T, absolute=FALSE, dim = dim, plotting = TRUE)
+
+#' ### Joint model
+#'
+#+ warning = FALSE, message = FALSE, error = FALSE
+#joint model (no covariate on bias)
+source("Run models joint.R")
+mod_3 <- joint_model(structured_data, unstructured_data, dat1, biasfield)
+source("validation_function.R")
+validation_3 <- validation_function(result=mod_3[[2]], resolution=c(10,10), join.stack=mod_3[[1]], model_type="joint",
+                                    unstructured_data = unstructured_data, structured_data = structured_data,
+                                    dat1 = dat1, summary_results=T, absolute=TRUE, dim = dim, plotting = TRUE)
+validation_3_r <- validation_function(result=mod_3[[2]], resolution=c(10,10), join.stack=mod_3[[1]], model_type="joint",
+                                      unstructured_data = unstructured_data, structured_data = structured_data,
+                                      dat1 = dat1, summary_results=T, absolute=FALSE, dim = dim, plotting = TRUE)
 
 
 #' ### Unstructured model with covariate for bias
@@ -172,58 +173,58 @@ validation_4 <- validation_function(result=mod_4[[2]], resolution=c(10,10), join
 validation_4_r <- validation_function(result=mod_4[[2]], resolution=c(10,10), join.stack=mod_4[[1]], model_type="unstructuredcov", 
                                        unstructured_data = unstructured_data, dat1 = dat1, summary_results=T, absolute=FALSE, dim = dim, plotting = TRUE)
 
-# 
-# #joint model (covariate on bias)
-# source("Run models joint covariate for bias.R")
-# mod_5 <- joint_model_cov(structured_data, unstructured_data, dat1, biasfield, resolution = c(10,10), biascov = biascov)
-# source("validation_function.R")
-# validation_5 <- validation_function(result=mod_5[[2]], resolution=c(10,10), join.stack=mod_5[[1]], model_type="jointcov", 
-#                                     unstructured_data = unstructured_data, structured_data = structured_data,
-#                                     dat1 = dat1, summary_results=T, absolute = TRUE, dim = dim, plotting = TRUE)
-# validation_5_r <- validation_function(result=mod_5[[2]], resolution=c(10,10), join.stack=mod_5[[1]], model_type="jointcov", 
-#                                     unstructured_data = unstructured_data, structured_data = structured_data,
-#                                     dat1 = dat1, summary_results=T, absolute = FALSE, dim = dim, plotting = TRUE)
-# 
-# 
-# ##joint model with second spatial field
-# source("Run models joint second field.R")
-# mod_6 <- joint_model2(structured_data, unstructured_data, dat1, biasfield)
-# source("validation_function.R")
-# validation_6 <- validation_function(result=mod_6[[2]], resolution=c(10,10), join.stack=mod_6[[1]], model_type="joint2", 
-#                                     unstructured_data = unstructured_data, structured_data = structured_data,
-#                                     dat1 = dat1, summary_results=T, absolute = TRUE, dim = dim, plotting = TRUE)
-# validation_6_r <- validation_function(result=mod_6[[2]], resolution=c(10,10), join.stack=mod_6[[1]], model_type="joint2", 
-#                                     unstructured_data = unstructured_data, structured_data = structured_data,
-#                                     dat1 = dat1, summary_results=T, absolute = FALSE, dim = dim, plotting = TRUE)
-# 
+#
+#joint model (covariate on bias)
+source("Run models joint covariate for bias.R")
+mod_5 <- joint_model_cov(structured_data, unstructured_data, dat1, biasfield, resolution = c(10,10), biascov = biascov)
+source("validation_function.R")
+validation_5 <- validation_function(result=mod_5[[2]], resolution=c(10,10), join.stack=mod_5[[1]], model_type="jointcov",
+                                    unstructured_data = unstructured_data, structured_data = structured_data,
+                                    dat1 = dat1, summary_results=T, absolute = TRUE, dim = dim, plotting = TRUE)
+validation_5_r <- validation_function(result=mod_5[[2]], resolution=c(10,10), join.stack=mod_5[[1]], model_type="jointcov",
+                                    unstructured_data = unstructured_data, structured_data = structured_data,
+                                    dat1 = dat1, summary_results=T, absolute = FALSE, dim = dim, plotting = TRUE)
+
+
+##joint model with second spatial field
+source("Run models joint second field.R")
+mod_6 <- joint_model2(structured_data, unstructured_data, dat1, biasfield)
+source("validation_function.R")
+validation_6 <- validation_function(result=mod_6[[2]], resolution=c(10,10), join.stack=mod_6[[1]], model_type="joint2",
+                                    unstructured_data = unstructured_data, structured_data = structured_data,
+                                    dat1 = dat1, summary_results=T, absolute = TRUE, dim = dim, plotting = TRUE)
+validation_6_r <- validation_function(result=mod_6[[2]], resolution=c(10,10), join.stack=mod_6[[1]], model_type="joint2",
+                                    unstructured_data = unstructured_data, structured_data = structured_data,
+                                    dat1 = dat1, summary_results=T, absolute = FALSE, dim = dim, plotting = TRUE)
+
 
 
 #note these are now from the relative validation
 
 
 ## Compare Mean Absolute Error between models
-# validation_1_r$'Proto-table'
+validation_1_r$'Proto-table'
 validation_2_r$'Proto-table'
-# validation_3_r$'Proto-table'
+validation_3_r$'Proto-table'
 validation_4_r$'Proto-table'
-# validation_5_r$'Proto-table'
-# validation_6_r$'Proto-table'
-# 
+validation_5_r$'Proto-table'
+validation_6_r$'Proto-table'
+#
 # ## Compare estimation of environmental covariate between models
-# mod_1$result$summary.fixed
+mod_1$result$summary.fixed
 mod_2$result$summary.fixed
-# mod_3$result$summary.fixed
+mod_3$result$summary.fixed
 mod_4$result$summary.fixed
-# mod_5$result$summary.fixed
-# mod_6$result$summary.fixed
+mod_5$result$summary.fixed
+mod_6$result$summary.fixed
 
 ## Compare correlation of true vs estimated relative intensities
-# validation_1_r$correlation
+validation_1_r$correlation
 validation_2_r$correlation
-# validation_3_r$correlation
+validation_3_r$correlation
 validation_4_r$correlation
-# validation_5_r$correlation
-# validation_6_r$correlation
+validation_5_r$correlation
+validation_6_r$correlation
 
 
 

--- a/runall.R
+++ b/runall.R
@@ -6,6 +6,8 @@ source("setParams.R")
 
 library(viridis)
 
+lambda <- -3
+
 #' The default parameters are as follows:
 #' 
 #' - simulation is conducted on a grid of 300*300  
@@ -121,14 +123,14 @@ legend(-10,360,c("Absence", "Presence"), pch = 21, col = "black", pt.bg = c(0,1)
 #' 
 #' ### Structured model 
 #' 
-#+ warning = FALSE, message = FALSE, error = FALSE, figure.align = "center"
-source("Run models structured.R")
-mod_1 <- structured_model(structured_data, dat1, biasfield, plotting = TRUE)
-source("validation_function.R")
-validation_1 <- validation_function(result=mod_1[[2]], resolution=c(10,10), join.stack=mod_1[[1]], model_type="structured", 
-                                    structured_data = structured_data, dat1 = dat1, summary_results=T, qsize = 1, absolute=TRUE, dim = dim, plotting = TRUE)
-validation_1_r <- validation_function(result=mod_1[[2]], resolution=c(10,10), join.stack=mod_1[[1]], model_type="structured", 
-                                      structured_data = structured_data, dat1 = dat1, summary_results=T, qsize = 1, absolute=FALSE, dim = dim, plotting = TRUE)
+# #+ warning = FALSE, message = FALSE, error = FALSE, figure.align = "center"
+# source("Run models structured.R")
+# mod_1 <- structured_model(structured_data, dat1, biasfield, plotting = TRUE)
+# source("validation_function.R")
+# validation_1 <- validation_function(result=mod_1[[2]], resolution=c(10,10), join.stack=mod_1[[1]], model_type="structured", 
+#                                     structured_data = structured_data, dat1 = dat1, summary_results=T, qsize = 1, absolute=TRUE, dim = dim, plotting = TRUE)
+# validation_1_r <- validation_function(result=mod_1[[2]], resolution=c(10,10), join.stack=mod_1[[1]], model_type="structured", 
+#                                       structured_data = structured_data, dat1 = dat1, summary_results=T, qsize = 1, absolute=FALSE, dim = dim, plotting = TRUE)
 
 #' ### Unstructured model 
 #' 
@@ -143,20 +145,20 @@ validation_2_r <- validation_function(result=mod_2[[2]], resolution=c(10,10), jo
 
 
 
-
-#' ### Joint model 
 #' 
-#+ warning = FALSE, message = FALSE, error = FALSE
-#joint model (no covariate on bias)
-source("Run models joint.R")
-mod_3 <- joint_model(structured_data, unstructured_data, dat1, biasfield)
-source("validation_function.R")
-validation_3 <- validation_function(result=mod_3[[2]], resolution=c(10,10), join.stack=mod_3[[1]], model_type="joint", 
-                                    unstructured_data = unstructured_data, structured_data = structured_data,
-                                    dat1 = dat1, summary_results=T, absolute=TRUE, dim = dim, plotting = TRUE)
-validation_3_r <- validation_function(result=mod_3[[2]], resolution=c(10,10), join.stack=mod_3[[1]], model_type="joint", 
-                                      unstructured_data = unstructured_data, structured_data = structured_data,
-                                      dat1 = dat1, summary_results=T, absolute=FALSE, dim = dim, plotting = TRUE)
+#' #' ### Joint model 
+#' #' 
+#' #+ warning = FALSE, message = FALSE, error = FALSE
+#' #joint model (no covariate on bias)
+#' source("Run models joint.R")
+#' mod_3 <- joint_model(structured_data, unstructured_data, dat1, biasfield)
+#' source("validation_function.R")
+#' validation_3 <- validation_function(result=mod_3[[2]], resolution=c(10,10), join.stack=mod_3[[1]], model_type="joint", 
+#'                                     unstructured_data = unstructured_data, structured_data = structured_data,
+#'                                     dat1 = dat1, summary_results=T, absolute=TRUE, dim = dim, plotting = TRUE)
+#' validation_3_r <- validation_function(result=mod_3[[2]], resolution=c(10,10), join.stack=mod_3[[1]], model_type="joint", 
+#'                                       unstructured_data = unstructured_data, structured_data = structured_data,
+#'                                       dat1 = dat1, summary_results=T, absolute=FALSE, dim = dim, plotting = TRUE)
 
 
 #' ### Unstructured model with covariate for bias
@@ -170,58 +172,58 @@ validation_4 <- validation_function(result=mod_4[[2]], resolution=c(10,10), join
 validation_4_r <- validation_function(result=mod_4[[2]], resolution=c(10,10), join.stack=mod_4[[1]], model_type="unstructuredcov", 
                                        unstructured_data = unstructured_data, dat1 = dat1, summary_results=T, absolute=FALSE, dim = dim, plotting = TRUE)
 
-
-#joint model (covariate on bias)
-source("Run models joint covariate for bias.R")
-mod_5 <- joint_model_cov(structured_data, unstructured_data, dat1, biasfield, resolution = c(10,10), biascov = biascov)
-source("validation_function.R")
-validation_5 <- validation_function(result=mod_5[[2]], resolution=c(10,10), join.stack=mod_5[[1]], model_type="jointcov", 
-                                    unstructured_data = unstructured_data, structured_data = structured_data,
-                                    dat1 = dat1, summary_results=T, absolute = TRUE, dim = dim, plotting = TRUE)
-validation_5_r <- validation_function(result=mod_5[[2]], resolution=c(10,10), join.stack=mod_5[[1]], model_type="jointcov", 
-                                    unstructured_data = unstructured_data, structured_data = structured_data,
-                                    dat1 = dat1, summary_results=T, absolute = FALSE, dim = dim, plotting = TRUE)
-
-
-##joint model with second spatial field
-source("Run models joint second field.R")
-mod_6 <- joint_model2(structured_data, unstructured_data, dat1, biasfield)
-source("validation_function.R")
-validation_6 <- validation_function(result=mod_6[[2]], resolution=c(10,10), join.stack=mod_6[[1]], model_type="joint2", 
-                                    unstructured_data = unstructured_data, structured_data = structured_data,
-                                    dat1 = dat1, summary_results=T, absolute = TRUE, dim = dim, plotting = TRUE)
-validation_6_r <- validation_function(result=mod_6[[2]], resolution=c(10,10), join.stack=mod_6[[1]], model_type="joint2", 
-                                    unstructured_data = unstructured_data, structured_data = structured_data,
-                                    dat1 = dat1, summary_results=T, absolute = FALSE, dim = dim, plotting = TRUE)
-
+# 
+# #joint model (covariate on bias)
+# source("Run models joint covariate for bias.R")
+# mod_5 <- joint_model_cov(structured_data, unstructured_data, dat1, biasfield, resolution = c(10,10), biascov = biascov)
+# source("validation_function.R")
+# validation_5 <- validation_function(result=mod_5[[2]], resolution=c(10,10), join.stack=mod_5[[1]], model_type="jointcov", 
+#                                     unstructured_data = unstructured_data, structured_data = structured_data,
+#                                     dat1 = dat1, summary_results=T, absolute = TRUE, dim = dim, plotting = TRUE)
+# validation_5_r <- validation_function(result=mod_5[[2]], resolution=c(10,10), join.stack=mod_5[[1]], model_type="jointcov", 
+#                                     unstructured_data = unstructured_data, structured_data = structured_data,
+#                                     dat1 = dat1, summary_results=T, absolute = FALSE, dim = dim, plotting = TRUE)
+# 
+# 
+# ##joint model with second spatial field
+# source("Run models joint second field.R")
+# mod_6 <- joint_model2(structured_data, unstructured_data, dat1, biasfield)
+# source("validation_function.R")
+# validation_6 <- validation_function(result=mod_6[[2]], resolution=c(10,10), join.stack=mod_6[[1]], model_type="joint2", 
+#                                     unstructured_data = unstructured_data, structured_data = structured_data,
+#                                     dat1 = dat1, summary_results=T, absolute = TRUE, dim = dim, plotting = TRUE)
+# validation_6_r <- validation_function(result=mod_6[[2]], resolution=c(10,10), join.stack=mod_6[[1]], model_type="joint2", 
+#                                     unstructured_data = unstructured_data, structured_data = structured_data,
+#                                     dat1 = dat1, summary_results=T, absolute = FALSE, dim = dim, plotting = TRUE)
+# 
 
 
 #note these are now from the relative validation
 
 
 ## Compare Mean Absolute Error between models
-validation_1_r$'Proto-table'
+# validation_1_r$'Proto-table'
 validation_2_r$'Proto-table'
-validation_3_r$'Proto-table'
+# validation_3_r$'Proto-table'
 validation_4_r$'Proto-table'
-validation_5_r$'Proto-table'
-validation_6_r$'Proto-table'
-
-## Compare estimation of environmental covariate between models
-mod_1$result$summary.fixed
+# validation_5_r$'Proto-table'
+# validation_6_r$'Proto-table'
+# 
+# ## Compare estimation of environmental covariate between models
+# mod_1$result$summary.fixed
 mod_2$result$summary.fixed
-mod_3$result$summary.fixed
+# mod_3$result$summary.fixed
 mod_4$result$summary.fixed
-mod_5$result$summary.fixed
-mod_6$result$summary.fixed
+# mod_5$result$summary.fixed
+# mod_6$result$summary.fixed
 
 ## Compare correlation of true vs estimated relative intensities
-validation_1_r$correlation
+# validation_1_r$correlation
 validation_2_r$correlation
-validation_3_r$correlation
+# validation_3_r$correlation
 validation_4_r$correlation
-validation_5_r$correlation
-validation_6_r$correlation
+# validation_5_r$correlation
+# validation_6_r$correlation
 
 
 

--- a/runall.R
+++ b/runall.R
@@ -4,6 +4,8 @@
 #' 
 source("setParams.R")
 
+library(viridis)
+
 #' The default parameters are as follows:
 #' 
 #' - simulation is conducted on a grid of 300*300  
@@ -61,8 +63,9 @@ image.plot(list(x=dat1$Lam$xcol, y=dat1$Lam$yrow, z=t(biascov)), main='Bias cova
 #+ echo = FALSE 
 par(mfrow=c(1,1), xpd = TRUE) 
 par(mar=c(4,4,4,7))
-plot(strata1$y ~ strata1$x, col = strata1$stratum)
-legend(110,300, fill = unique(strata1$stratum), legend = probs, title = "Probability")
+palette(viridis(50))
+plot(biasfield$y ~ biasfield$x, col = biasfield$stratprobs*100)
+legend(330,300, col = c(50,40,30,20,10), pch = 20, legend = c("0.4-0.5", "0.3-0.4", "0.2-0.3", "0.1-0.2", "0.01-0.1"), title = "Probability")
 
 #' Visualise thinned unstructured data
 #+ echo = FALSE 

--- a/setParams.R
+++ b/setParams.R
@@ -2,7 +2,7 @@
 
 #genData
 dim = c(300,300)
-lambda = 0.5
+lambda = -3
 env.beta = 1.2
 plotdat = TRUE
 seed = NULL


### PR DESCRIPTION
Edits to change the spatial bias in sampling unstructured data from discrete to continuous. Changes made are as follows:

1. Spatial bias in unstructured sampling is now generated from a continuous exponential function from the maximum probability. Bias can be either correlated or uncorrelated with the environmental gradient

2. The covariate to explain the bias is generated with a known correlation (currently set at 0.99 to generate a near perfect covariate)

3. The minimum probability of sampling a point is now the maximum probability divided by 10. This is a smaller gradient in probability than before (from 0.5 to 0.01 by default) because if the gradient was any stronger it swamped the spatial pattern in the data, even with a nearly perfect covariate. This indicates that in situations where the effect of bias is much larger than true variation the spatial field may represent the bias instead of the real distribution even with a nearly perfect covariate. This probably deserves further investigation - should our env covariate be stronger in our default setting? 

To do before accepting pull request:

- [x] Emily to please run a small test simulation on this branch to check performance on multiple runs

- [x] Emily/others to sense check new code and results

Reject pull request if model performance is significantly altered from the previous sampling method